### PR TITLE
Bump rLogin version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@rsksmart/rlogin-essentials",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rlogin-essentials",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
         "@portis/web3": "^4.0.6",
-        "@rsksmart/rlogin": "1.2.0",
+        "@rsksmart/rlogin": "1.3.1",
         "@rsksmart/rlogin-dcent-provider": "^1.0.1",
-        "@rsksmart/rlogin-ledger-provider": "^1.0.1",
-        "@rsksmart/rlogin-trezor-provider": "^1.0.1",
+        "@rsksmart/rlogin-ledger-provider": "^1.0.2",
+        "@rsksmart/rlogin-trezor-provider": "^1.0.2",
         "@walletconnect/web3-provider": "^1.6.6"
       },
       "devDependencies": {
@@ -1964,14 +1964,16 @@
       "integrity": "sha512-SKHgsjVysiIVv6xyDOVuubVPVT7qMQ0y7IWOj2j73Hmgq/dSgyouXc2kl6THh0Vqh9ri5J3R+rKuXRzXmv/HvA=="
     },
     "node_modules/@rsksmart/rlogin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin/-/rlogin-1.2.0.tgz",
-      "integrity": "sha512-x7Cx0DOl3JaSNof3dW4CQy1wr4X7gr7Eemmr+3Y7WqdRbE8IXzP3MF8ko7OAhmX1efk0MpDpFiixPywQHC0MPg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin/-/rlogin-1.3.1.tgz",
+      "integrity": "sha512-olVy6vmRShlgZUzAPYfW95Jq/ItS4WECTIa84mJRQ1wg8sLKkIQEwHDId8p+V8df6CdCCuwepTSPqYb+YrC01Q==",
       "dependencies": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",
+        "@rsksmart/rlogin-dpath": "^1.0.1",
         "@rsksmart/vc-json-schemas-parser": "^1.0.0",
         "@types/styled-components": "^5.1.3",
         "axios": "^0.21.1",
+        "buffer": "^6.0.3",
         "ethr-did-resolver": "^3.0.2",
         "i18next": "^20.3.5",
         "i18next-browser-languagedetector": "^6.1.2",
@@ -1997,14 +1999,14 @@
       }
     },
     "node_modules/@rsksmart/rlogin-dpath": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-dpath/-/rlogin-dpath-1.0.1.tgz",
-      "integrity": "sha512-97aalCxqCy6/JyE5eefka2isC9rU2hfvspQRfkvEVKB3zGJsC/xK0onDwCFH0kBCdkUn2K3lLO0GRnOStdbpIQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-dpath/-/rlogin-dpath-1.0.3.tgz",
+      "integrity": "sha512-uWrzaQbnApLIBdVNqF2NdqdfIJ2jG0XrSFC+XJ5Wuo2nap4PVxc45U+GlmTy1qqK9PJ0g/d9F/dR5n51EhqlVw=="
     },
     "node_modules/@rsksmart/rlogin-eip1193-proxy-subprovider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-eip1193-proxy-subprovider/-/rlogin-eip1193-proxy-subprovider-1.0.1.tgz",
-      "integrity": "sha512-OIlaosjIPNJcBg+iNAHgq/POsZJZ3I71hRSyzniIB71VdrY7R2p/Uch63XLfzuD+Md7vzQ6NiAmWepEC5HivkQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-eip1193-proxy-subprovider/-/rlogin-eip1193-proxy-subprovider-1.0.2.tgz",
+      "integrity": "sha512-CefI6gtv4shMgbWkEakkHF8Igcx7juTrqWJqk8qGAozHU5hsf+yk5yYkrGsCuAI/mz98X2ewhe6Cwuly6hOTIw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "ethjs-provider-http": "^0.1.6",
@@ -2012,17 +2014,17 @@
       }
     },
     "node_modules/@rsksmart/rlogin-ledger-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-ledger-provider/-/rlogin-ledger-provider-1.0.1.tgz",
-      "integrity": "sha512-WrhHXOGv/qzcxnAlroLvPb5b5e0kiRA36p4COWuzLYFlC9ivBCZThrXSPC4hZFAgHlzS6ZziIk56u2T4OIz4MQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-ledger-provider/-/rlogin-ledger-provider-1.0.2.tgz",
+      "integrity": "sha512-0836xSv6TrXEO/ybZjwRAQF5mAs3sI3tbXKFPWMlfqRpCyj1tCoFl3Q5b2HX36QRw+8YePiCUXQ7cX2RnvXe+A==",
       "dependencies": {
         "@ethereumjs/tx": "^3.3.0",
         "@ledgerhq/hw-app-eth": "^6.2.0",
         "@ledgerhq/hw-transport-webhid": "^6.4.1",
         "@ledgerhq/hw-transport-webusb": "^6.3.0",
-        "@rsksmart/rlogin-dpath": "^1.0.1",
-        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.1",
-        "@rsksmart/rlogin-transactions": "^1.0.1",
+        "@rsksmart/rlogin-dpath": "^1.0.3",
+        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.2",
+        "@rsksmart/rlogin-transactions": "^1.0.2",
         "assert": "^2.0.0",
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
@@ -2035,9 +2037,9 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@rsksmart/rlogin-transactions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.1.tgz",
-      "integrity": "sha512-4t1FZH6h2TnLfFbfhfY29ENmbTvg56PC6j7awYuWpiQUF/1tMUnrUJ9QX7IaTSJ2QX2QaHu4CuG811iaPRhR0A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.2.tgz",
+      "integrity": "sha512-O0UQbeoEj1ynkk7iKTIAxB1YyomfDtA+k1uLeED8hrSd7goNeRWeZj4bmArVV4c3+1msvuVKXlm5n5LXVoPIaA==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -2048,19 +2050,19 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@rsksmart/rlogin-trezor-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-trezor-provider/-/rlogin-trezor-provider-1.0.1.tgz",
-      "integrity": "sha512-EFQv3gYcxWiyNbZyd4ErMC+2zAnIOSNUfhXLOg3ZMD4bTh9ccjydH6tUMAfNli1lE9xabNQP84dBeQu/Mc2EIw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-trezor-provider/-/rlogin-trezor-provider-1.0.2.tgz",
+      "integrity": "sha512-2vIr7oRUyv7OodMxANGl2Ty+alVWEE5byK3+kSfXJdLkzhCDsNojlBOgASKZ7PFqQpu+1E4HqiwTq5mJaoNNTw==",
       "dependencies": {
         "@ethereumjs/tx": "^3.3.0",
-        "@rsksmart/rlogin-dpath": "^1.0.1",
-        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.1",
-        "@rsksmart/rlogin-transactions": "^1.0.1",
+        "@rsksmart/rlogin-dpath": "^1.0.3",
+        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.2",
+        "@rsksmart/rlogin-transactions": "^1.0.2",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "ethjs-provider-http": "^0.1.6",
         "stream-browserify": "^3.0.0",
-        "trezor-connect": "^8.2.1"
+        "trezor-connect": "^8.2.5"
       }
     },
     "node_modules/@rsksmart/vc-json-schemas-parser": {
@@ -11732,13 +11734,59 @@
       }
     },
     "node_modules/trezor-connect": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.1.tgz",
-      "integrity": "sha512-YqGgB6E440j8DHaIJCZumtjg5LdUgQyow2pzQRAIVFchhbTOgU3FnWGO3vEeRn9UQuY3pj8xVo0A0GKEtHAW8g==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.7.tgz",
+      "integrity": "sha512-SoRDqZoTLb7W0nk7B9OimRoUCGRUc6htEJrHcB0nbC1Fs6Uw5lxCGn/agYCbqgX3oiWs2MIu0UMt+1Ky634Enw==",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "events": "^3.2.0",
-        "whatwg-fetch": "^3.5.0"
+        "@babel/runtime": "^7.15.4",
+        "cross-fetch": "^3.1.5",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/trezor-connect/node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/trezor-connect/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/trezor-connect/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/trezor-connect/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/trezor-connect/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/ts-jest": {
@@ -12517,11 +12565,6 @@
       "dependencies": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
@@ -14218,14 +14261,16 @@
       "integrity": "sha512-SKHgsjVysiIVv6xyDOVuubVPVT7qMQ0y7IWOj2j73Hmgq/dSgyouXc2kl6THh0Vqh9ri5J3R+rKuXRzXmv/HvA=="
     },
     "@rsksmart/rlogin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin/-/rlogin-1.2.0.tgz",
-      "integrity": "sha512-x7Cx0DOl3JaSNof3dW4CQy1wr4X7gr7Eemmr+3Y7WqdRbE8IXzP3MF8ko7OAhmX1efk0MpDpFiixPywQHC0MPg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin/-/rlogin-1.3.1.tgz",
+      "integrity": "sha512-olVy6vmRShlgZUzAPYfW95Jq/ItS4WECTIa84mJRQ1wg8sLKkIQEwHDId8p+V8df6CdCCuwepTSPqYb+YrC01Q==",
       "requires": {
         "@rsksmart/ipfs-cpinner-client-types": "^0.1.3",
+        "@rsksmart/rlogin-dpath": "^1.0.1",
         "@rsksmart/vc-json-schemas-parser": "^1.0.0",
         "@types/styled-components": "^5.1.3",
         "axios": "^0.21.1",
+        "buffer": "^6.0.3",
         "ethr-did-resolver": "^3.0.2",
         "i18next": "^20.3.5",
         "i18next-browser-languagedetector": "^6.1.2",
@@ -14251,14 +14296,14 @@
       }
     },
     "@rsksmart/rlogin-dpath": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-dpath/-/rlogin-dpath-1.0.1.tgz",
-      "integrity": "sha512-97aalCxqCy6/JyE5eefka2isC9rU2hfvspQRfkvEVKB3zGJsC/xK0onDwCFH0kBCdkUn2K3lLO0GRnOStdbpIQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-dpath/-/rlogin-dpath-1.0.3.tgz",
+      "integrity": "sha512-uWrzaQbnApLIBdVNqF2NdqdfIJ2jG0XrSFC+XJ5Wuo2nap4PVxc45U+GlmTy1qqK9PJ0g/d9F/dR5n51EhqlVw=="
     },
     "@rsksmart/rlogin-eip1193-proxy-subprovider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-eip1193-proxy-subprovider/-/rlogin-eip1193-proxy-subprovider-1.0.1.tgz",
-      "integrity": "sha512-OIlaosjIPNJcBg+iNAHgq/POsZJZ3I71hRSyzniIB71VdrY7R2p/Uch63XLfzuD+Md7vzQ6NiAmWepEC5HivkQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-eip1193-proxy-subprovider/-/rlogin-eip1193-proxy-subprovider-1.0.2.tgz",
+      "integrity": "sha512-CefI6gtv4shMgbWkEakkHF8Igcx7juTrqWJqk8qGAozHU5hsf+yk5yYkrGsCuAI/mz98X2ewhe6Cwuly6hOTIw==",
       "requires": {
         "buffer": "^6.0.3",
         "ethjs-provider-http": "^0.1.6",
@@ -14266,17 +14311,17 @@
       }
     },
     "@rsksmart/rlogin-ledger-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-ledger-provider/-/rlogin-ledger-provider-1.0.1.tgz",
-      "integrity": "sha512-WrhHXOGv/qzcxnAlroLvPb5b5e0kiRA36p4COWuzLYFlC9ivBCZThrXSPC4hZFAgHlzS6ZziIk56u2T4OIz4MQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-ledger-provider/-/rlogin-ledger-provider-1.0.2.tgz",
+      "integrity": "sha512-0836xSv6TrXEO/ybZjwRAQF5mAs3sI3tbXKFPWMlfqRpCyj1tCoFl3Q5b2HX36QRw+8YePiCUXQ7cX2RnvXe+A==",
       "requires": {
         "@ethereumjs/tx": "^3.3.0",
         "@ledgerhq/hw-app-eth": "^6.2.0",
         "@ledgerhq/hw-transport-webhid": "^6.4.1",
         "@ledgerhq/hw-transport-webusb": "^6.3.0",
-        "@rsksmart/rlogin-dpath": "^1.0.1",
-        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.1",
-        "@rsksmart/rlogin-transactions": "^1.0.1",
+        "@rsksmart/rlogin-dpath": "^1.0.3",
+        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.2",
+        "@rsksmart/rlogin-transactions": "^1.0.2",
         "assert": "^2.0.0",
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
@@ -14291,9 +14336,9 @@
       }
     },
     "@rsksmart/rlogin-transactions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.1.tgz",
-      "integrity": "sha512-4t1FZH6h2TnLfFbfhfY29ENmbTvg56PC6j7awYuWpiQUF/1tMUnrUJ9QX7IaTSJ2QX2QaHu4CuG811iaPRhR0A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-transactions/-/rlogin-transactions-1.0.2.tgz",
+      "integrity": "sha512-O0UQbeoEj1ynkk7iKTIAxB1YyomfDtA+k1uLeED8hrSd7goNeRWeZj4bmArVV4c3+1msvuVKXlm5n5LXVoPIaA==",
       "requires": {
         "bn.js": "^5.2.0"
       },
@@ -14306,19 +14351,19 @@
       }
     },
     "@rsksmart/rlogin-trezor-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-trezor-provider/-/rlogin-trezor-provider-1.0.1.tgz",
-      "integrity": "sha512-EFQv3gYcxWiyNbZyd4ErMC+2zAnIOSNUfhXLOg3ZMD4bTh9ccjydH6tUMAfNli1lE9xabNQP84dBeQu/Mc2EIw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rlogin-trezor-provider/-/rlogin-trezor-provider-1.0.2.tgz",
+      "integrity": "sha512-2vIr7oRUyv7OodMxANGl2Ty+alVWEE5byK3+kSfXJdLkzhCDsNojlBOgASKZ7PFqQpu+1E4HqiwTq5mJaoNNTw==",
       "requires": {
         "@ethereumjs/tx": "^3.3.0",
-        "@rsksmart/rlogin-dpath": "^1.0.1",
-        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.1",
-        "@rsksmart/rlogin-transactions": "^1.0.1",
+        "@rsksmart/rlogin-dpath": "^1.0.3",
+        "@rsksmart/rlogin-eip1193-proxy-subprovider": "^1.0.2",
+        "@rsksmart/rlogin-transactions": "^1.0.2",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "ethjs-provider-http": "^0.1.6",
         "stream-browserify": "^3.0.0",
-        "trezor-connect": "^8.2.1"
+        "trezor-connect": "^8.2.5"
       }
     },
     "@rsksmart/vc-json-schemas-parser": {
@@ -17015,6 +17060,7 @@
     },
     "ethereumjs-abi": {
       "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+      "integrity": "sha512-qs8G5KwnIO/thOQjv1RvR/4oiTsy6IaCsN+ory5dbiqFXz8sd239aWJH0wmsVNPimL5X1KzQheUpi6xAo6FU4w==",
       "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
@@ -21991,13 +22037,50 @@
       }
     },
     "trezor-connect": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.1.tgz",
-      "integrity": "sha512-YqGgB6E440j8DHaIJCZumtjg5LdUgQyow2pzQRAIVFchhbTOgU3FnWGO3vEeRn9UQuY3pj8xVo0A0GKEtHAW8g==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.7.tgz",
+      "integrity": "sha512-SoRDqZoTLb7W0nk7B9OimRoUCGRUc6htEJrHcB0nbC1Fs6Uw5lxCGn/agYCbqgX3oiWs2MIu0UMt+1Ky634Enw==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "events": "^3.2.0",
-        "whatwg-fetch": "^3.5.0"
+        "@babel/runtime": "^7.15.4",
+        "cross-fetch": "^3.1.5",
+        "events": "^3.3.0"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "ts-jest": {
@@ -22650,11 +22733,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rlogin-essentials",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "rLogin essentials",
   "main": "dist/index.js",
   "declarations": "dist/index.d.ts",
@@ -45,10 +45,10 @@
   },
   "dependencies": {
     "@portis/web3": "^4.0.6",
-    "@rsksmart/rlogin": "1.2.0",
+    "@rsksmart/rlogin": "1.3.1",
     "@rsksmart/rlogin-dcent-provider": "^1.0.1",
-    "@rsksmart/rlogin-ledger-provider": "^1.0.1",
-    "@rsksmart/rlogin-trezor-provider": "^1.0.1",
+    "@rsksmart/rlogin-ledger-provider": "^1.0.2",
+    "@rsksmart/rlogin-trezor-provider": "^1.0.2",
     "@walletconnect/web3-provider": "^1.6.6"
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,10 @@
 import { createRLogin } from '../src'
 import * as RLogin from '@rsksmart/rlogin'
 
+jest.mock('@rsksmart/rlogin-dcent-provider', () => ({
+  DCentProvider: () => ({})
+}))
+
 describe('createRLogin', () => {
   const rpcUrlsMock = jest.fn()
   const supportedChainsMock = jest.fn()


### PR DESCRIPTION
Updates hardware packages too. 

Todo:

- Deploy 1.3.2 here: https://github.com/rsksmart/rLogin/pull/225